### PR TITLE
Use PATHS keyword in find_* methods.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ project(tinyxml_vendor)
 
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 find_package(TinyXML)
-
+# Look again, explicitly for config packages.
+find_package(TinyXML CONFIG)
 if (NOT TinyXML_FOUND)
   include(ExternalProject)
   ExternalProject_Add(tinyxml-2.6.2

--- a/cmake/Modules/FindTinyXML.cmake
+++ b/cmake/Modules/FindTinyXML.cmake
@@ -54,8 +54,8 @@ if(TinyXML_ROOT_DIR)
 endif()
 
 # Find headers and libraries
-find_path(TinyXML_INCLUDE_DIR NAMES tinyxml.h PATH_SUFFIXES "tinyxml" ${TinyXML_INCLUDE_PATH})
-find_library(TinyXML_LIBRARY  NAMES tinyxml   PATH_SUFFIXES "tinyxml" ${TinyXML_LIBRARY_PATH})
+find_path(TinyXML_INCLUDE_DIR NAMES tinyxml.h PATH_SUFFIXES "tinyxml" PATHS ${TinyXML_INCLUDE_PATH})
+find_library(TinyXML_LIBRARY  NAMES tinyxml   PATH_SUFFIXES "tinyxml" PATHS ${TinyXML_LIBRARY_PATH})
 
 mark_as_advanced(TinyXML_INCLUDE_DIR
                  TinyXML_LIBRARY)


### PR DESCRIPTION
According to the [docs for find_path](https://cmake.org/cmake/help/v3.5/command/find_path.html) and [find_library](https://cmake.org/cmake/help/v3.5/command/find_library.html) suggested paths need to be behind the PATHS keyword.

This will help get us closer to debugging Windows builds.

cc @Karsten1987 since we've been working on this.