### PR TITLE
add package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>tinyxml_vendor</name>
+  <version>0.4.0</version>
+  <description>CMake shim over the tinxml library.</description>
+  <maintainer email="steven@openrobotics.org">Steven! Ragnarök</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <depend>tinyxml</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Copied from https://github.com/ros2-gbp/tinyxml_vendor-release/blob/a0cd47f63740eb8d37d2d2615721537605976250/xenial/package.xml

@nuclearsandwich I removed the exported dependency on `cmake` to match [what we do for tinyxml2](https://github.com/ros2/tinyxml2_vendor/blob/84eddebcd65d140fecb71a5a0cb20c94cec60456/package.xml) 