### PR TITLE
[Windows] Honor CMAKE_BUILD_TYPE from the current CMakeLists.txt to build tinyxml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT TinyXML_FOUND)
     URL https://superb-dca2.dl.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz
     URL_MD5 c1b864c96804a10526540c664ade67f0
     CMAKE_ARGS
-      -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/tinyxml_install
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/tinyxml_install -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/tinyxml_install"
     PATCH_COMMAND
     ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/enforce-use-stl.patch


### PR DESCRIPTION
This problem manifests when I do a ROS2 Windows build by `colcon build --merge-install --event-handlers console_cohesion+ --install-base "C:\opt\ros\crystal\x64" --cmake-args -DCMAKE_BUILD_TYPE=Release`.

This is the error when linking `urdfdom_world.dll`:
```
CMakeFiles/urdfdom_world.dir/src/pose.cpp.obj CMakeFiles/urdfdom_world.dir/src/model.cpp.obj CMakeFiles/urdfdom_world.dir/src/link.cpp.obj CMakeFiles/urdfdom_world.dir/src/joint.cpp.obj CMakeFiles/urdfdom_world.dir/src/world.cpp.obj 
tinyxml.lib(tinyxml.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in pose.cpp.obj
tinyxml.lib(tinyxml.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MDd_DynamicDebug' doesn't match value 'MD_DynamicRelease' in pose.cpp.obj
tinyxml.lib(tinyxmlparser.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in pose.cpp.obj
tinyxml.lib(tinyxmlparser.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MDd_DynamicDebug' doesn't match value 'MD_DynamicRelease' in pose.cpp.obj
tinyxml.lib(tinyxmlerror.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in pose.cpp.obj
tinyxml.lib(tinyxmlerror.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MDd_DynamicDebug' doesn't match value 'MD_DynamicRelease' in pose.cpp.obj
   Creating library ..\lib\urdfdom_world.lib and object ..\lib\urdfdom_world.exp
LINK : warning LNK4098: defaultlib 'MSVCRTD' conflicts with use of other libs; use /NODEFAULTLIB:library
tinyxml.lib(tinyxml.obj) : error LNK2019: unresolved external symbol __imp__invalid_parameter referenced in function "void * __cdecl std::_Allocate_manually_vector_aligned<struct std::_Default_allocate_traits>(unsigned __int64)" (??$_Allocate_manually_vector_aligned@U_Default_allocate_traits@std@@@std@@YAPEAX_K@Z)
tinyxml.lib(tinyxmlparser.obj) : error LNK2001: unresolved external symbol __imp__invalid_parameter
tinyxml.lib(tinyxml.obj) : error LNK2019: unresolved external symbol __imp__CrtDbgReport referenced in function "void * __cdecl std::_Allocate_manually_vector_aligned<struct std::_Default_allocate_traits>(unsigned __int64)" (??$_Allocate_manually_vector_aligned@U_Default_allocate_traits@std@@@std@@YAPEAX_K@Z)
tinyxml.lib(tinyxmlparser.obj) : error LNK2001: unresolved external symbol __imp__CrtDbgReport
..\bin\urdfdom_world.dll : fatal error LNK1120: 2 unresolved externals
NMAKE : fatal error U1077: '"C:\Program Files\CMake\bin\cmake.exe"' : return code '0xffffffff'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64\nmake.exe"' : return code '0x2'
Stop.
--- stderr: urdfdom
```

And trace back I found CMAKE uses "Debug" configuration to build `tinyxml` and it doesn't match the option `-DCMAKE_BUILD_TYPE=Release` passed from COLCON.