### PR TITLE
Use soureforge direct link to download 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if (NOT TinyXML_FOUND)
   include(ExternalProject)
   ExternalProject_Add(tinyxml-2.6.2
     PREFIX tinyxml-2.6.2
-    URL https://superb-dca2.dl.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz
+    URL https://downloads.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz
     URL_MD5 c1b864c96804a10526540c664ade67f0
     CMAKE_ARGS
       -DBUILD_SHARED_LIBS=ON


### PR DESCRIPTION
The mirror we are using seems to be gone. It is causing the one nightly build that actually has to download the sources to fail. https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/325/

Fixes #15 

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>