### PR TITLE
Update cmake min version in tinyxml cmakelists.txt script

### DIFF
--- a/tinyxml_cmakelists.txt
+++ b/tinyxml_cmakelists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.4.6)
+cmake_minimum_required(VERSION 2.8.12)
 project(tinyxml)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_definitions(-DTIXML_USE_STL)


### PR DESCRIPTION
In the most recent release of cmake (3.19), they have started deprecating cmake versions < `2.8.12`. 

Example cmake warnings
https://ci.ros2.org/view/nightly/job/nightly_win_rel/1760/cmake/

Build all of ros2, testing up to `rcutils`
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13157)](http://ci.ros2.org/job/ci_linux/13157/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8088)](http://ci.ros2.org/job/ci_linux-aarch64/8088/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10872)](http://ci.ros2.org/job/ci_osx/10872/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13162)](http://ci.ros2.org/job/ci_windows/13162/)


Signed-off-by: Stephen Brawner <brawner@gmail.com>