### PR TITLE
Resolve CMake warnings when the external project is built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,12 @@ endif()
 
 
 if (NOT TinyXML_FOUND)
+  set(extra_cmake_args)
+
+  if(DEFINED CMAKE_BUILD_TYPE)
+    list(APPEND extra_cmake_args "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+  endif()
+
   include(ExternalProject)
   ExternalProject_Add(tinyxml-2.6.2
     PREFIX tinyxml-2.6.2
@@ -21,11 +27,11 @@ if (NOT TinyXML_FOUND)
     URL_MD5 c1b864c96804a10526540c664ade67f0
     CMAKE_ARGS
       -DBUILD_SHARED_LIBS=ON
-      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/tinyxml_install
       -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
       -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+      ${extra_cmake_args}
     INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/tinyxml_install"
     PATCH_COMMAND
     ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/enforce-use-stl.patch

--- a/tinyxml_cmakelists.txt
+++ b/tinyxml_cmakelists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.4.6)
+cmake_minimum_required(VERSION 3.5)
 project(tinyxml)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_definitions(-DTIXML_USE_STL)


### PR DESCRIPTION
There is no reason for the external project's minimum CMake version to be less than the vendor package's cmake version. This should help avoid some CMake warnings.

Also, we shouldn't pass CMAKE_BUILD_TYPE if it isn't set, as is the case on Windows where the build type is specified using a different mechanism.

Before:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13600)](http://ci.ros2.org/job/ci_linux/13600/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8482)](http://ci.ros2.org/job/ci_linux-aarch64/8482/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11313)](http://ci.ros2.org/job/ci_osx/11313/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13657)](http://ci.ros2.org/job/ci_windows/13657/)

After:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13603)](http://ci.ros2.org/job/ci_linux/13603/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8485)](http://ci.ros2.org/job/ci_linux-aarch64/8485/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11316)](http://ci.ros2.org/job/ci_osx/11316/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13660)](http://ci.ros2.org/job/ci_windows/13660/)